### PR TITLE
Add tynding to path-to-description.txt

### DIFF
--- a/path-to-description.txt
+++ b/path-to-description.txt
@@ -1,2 +1,3 @@
 https://raw.githubusercontent.com/brownag/geodensity/refs/heads/main/DESCRIPTION
 https://raw.githubusercontent.com/LAPKB/Pmetrics/refs/heads/main/DESCRIPTION
+https://raw.githubusercontent.com/y-sunflower/tynding/refs/heads/main/DESCRIPTION


### PR DESCRIPTION
Hey! I already did this PR a few months ago, but then tynding was available on CRAN (which why I think it has been removed from `path-to-description.txt`). But since then it was removed and I haven't had time to bring it back so in the meantime I'm adding it back here.